### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,28 @@
+# Documentation Index
+
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/API/APIReference.md
+- [](&)Documentation/APIReference.md
+- [](&)Documentation/ApplicationSecurityAPI.md
+- [](&)Documentation/AuditAPI.md
+- [](&)Documentation/AuditGuide.md
+- [](&)Documentation/AuthenticationAPI.md
+- [](&)Documentation/AuthenticationGuide.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/ComplianceAPI.md
+- [](&)Documentation/ComplianceGuide.md
+- [](&)Documentation/EncryptionAPI.md
+- [](&)Documentation/EncryptionGuide.md
+- [](&)Documentation/Examples/UsageExamples.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/Guides/GettingStarted.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/KeyManagementAPI.md
+- [](&)Documentation/NetworkSecurityAPI.md
+- [](&)Documentation/NetworkSecurityGuide.md
+- [](&)Documentation/PerformanceOptimization.md
+- [](&)Documentation/SecurityBestPractices.md
+- [](&)Documentation/SecurityManagerAPI.md
+- [](&)Documentation/Troubleshooting.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,15 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/AdvancedExample.swift
+- ``Examples/AdvancedExample/AdvancedExample.swift
+- ``Examples/ApplicationSecurityExamples/ApplicationSecurityExample.swift
+- ``Examples/AuditExamples/AuditExample.swift
+- ``Examples/AuthenticationExamples/AuthenticationExample.swift
+- ``Examples/BasicExample.swift
+- ``Examples/BasicExample/BasicExample.swift
+- ``Examples/BasicExamples/BasicAuthenticationExample.swift
+- ``Examples/ComplianceExamples/ComplianceExample.swift
+- ``Examples/EncryptionExamples/DataEncryptionExample.swift
+- ``Examples/EncryptionExamples/EncryptionExample.swift
+- ``Examples/EnterpriseExample/EnterpriseExample.swift
+- ``Examples/NetworkSecurityExamples/NetworkSecurityExample.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.